### PR TITLE
Suppor for SimpleSAMLphp 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This version is compatible with [SimpleSAMLphp v1.17](https://simplesamlphp.org/
 
 - Comply to [PSR-4: Autoloader](https://www.php-fig.org/psr/psr-4/) guidelines
 - Comply to [PSR-12: Extended Coding Style](https://www.php-fig.org/psr/psr-12/) guidelines
+- Apply modern array syntax to comply with [SimpleSAMLphp v1.17](https://simplesamlphp.org/docs/stable/simplesamlphp-upgrade-notes-1.17)
 
 ## [v1.0.0] - 2020-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This version is compatible with [SimpleSAMLphp v1.17](https://simplesamlphp.org/
 ### Changed
 
 - Comply to [PSR-4: Autoloader](https://www.php-fig.org/psr/psr-4/) guidelines
+- Comply to [PSR-12: Extended Coding Style](https://www.php-fig.org/psr/psr-12/) guidelines
 
 ## [v1.0.0] - 2020-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+This version is compatible with [SimpleSAMLphp v1.17](https://simplesamlphp.org/docs/1.17/simplesamlphp-changelog)
+
+### Changed
+
+- Comply to [PSR-4: Autoloader](https://www.php-fig.org/psr/psr-4/) guidelines
+
 ## [v1.0.0] - 2020-11-11
 
 This version is compatible with

--- a/README.md
+++ b/README.md
@@ -69,18 +69,18 @@ modify the source code.
 ### Example authproc filter configuration
 
 ```php
-    authproc = array(
+    authproc = [
         ...
-        '60' => array(
+        '60' => [
             'class' => 'attrauthvoms:COmanageDbClient',
             'userIdAttribute' => 'distinguishedName',
-            'blacklist' => array(
+            'blacklist' => [
                 'https://www.example.org/sp',
-            ),
-            'voBlacklist' => array(
+            ],
+            'voBlacklist' => [
                 'vo.example.org',
-            ),
-        ),
+            ],
+        ],
 ```
 
 ## COmanage Database client for CertEntiltlement
@@ -138,29 +138,29 @@ The following authproc filter configuration options are supported:
 ### Example authproc filter configuration
 
 ```php
-    authproc = array(
+    authproc = [
         ...
-        61 => array(
+        61 => [
             'class' => 'attrauthvoms:COmanageDbClientCertEntitlement',
             'userIdAttribute' => 'distinguishedName',
             'attributeName' => 'certEntitlement',
-            'spWhitelist' => array(
+            'spWhitelist' => [
                 'https://www.example1.org/sp',
                 'https://www.example2.org/sp',
-            ),
-            'defaultRoles' => array(
+            ],
+            'defaultRoles' => [
                 'member',
                 'vm_operator'
-            ),
+            ],
             'allowEmptyRole' => true,
-            'voBlacklist' => array(
+            'voBlacklist' => [
                 'vo.example01.org',
                 'vo.example02.org',
-            ),
+            ],
             'role_urn_namespace' => 'urn:mace:example.org',
             'role_authority' => 'www.example.org',
             'defaultIssuerDn' => '',
-        ),
+        ],
 ```
 
 ## Compatibility matrix

--- a/lib/Auth/Process/COmanageDbClient.php
+++ b/lib/Auth/Process/COmanageDbClient.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SimpleSAML\Module\attrauthvoms\Auth\Process;
+
 /**
  * COmanage DB authproc filter.
  *
@@ -14,7 +16,7 @@
  *
  * @author Nicolas Liampotis <nliam@grnet.gr>
  */
-class sspmod_attrauthvoms_Auth_Process_COmanageDbClient extends SimpleSAML_Auth_ProcessingFilter
+class COmanageDbClient extends SimpleSAML\Auth\ProcessingFilter
 {
     // List of SP entity IDs that should be excluded from this filter.
     private $blacklist = array();
@@ -37,9 +39,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClient extends SimpleSAML_Auth_
 
         if (array_key_exists('userIdAttribute', $config)) {
             if (!is_string($config['userIdAttribute'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthvoms] Configuration error: 'userIdAttribute' not a string literal");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthvoms configuration error: 'userIdAttribute' not a string literal");
             }
             $this->userIdAttribute = $config['userIdAttribute'];
@@ -47,18 +49,18 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClient extends SimpleSAML_Auth_
 
         if (array_key_exists('blacklist', $config)) {
             if (!is_array($config['blacklist'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthvoms] Configuration error: 'blacklist' not an array");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthvoms configuration error: 'blacklist' not an array");
             }
             $this->blacklist = $config['blacklist'];
         }
         if (array_key_exists('voBlacklist', $config)) {
             if (!is_array($config['voBlacklist'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthcomanage] Configuration error: 'voBlacklist' not an array");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthcomanage configuration error: 'voBlacklist' not an array");
             }
             $this->voBlacklist = $config['voBlacklist'];
@@ -70,13 +72,13 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClient extends SimpleSAML_Auth_
         try {
             assert('is_array($state)');
             if (isset($state['SPMetadata']['entityid']) && in_array($state['SPMetadata']['entityid'], $this->blacklist, true)) {
-                SimpleSAML_Logger::debug(
+                SimpleSAML\Logger::debug(
                     "[attrauthvoms] process: Skipping blacklisted SP "
                     . var_export($state['SPMetadata']['entityid'], true));
                 return;
             }
             if (empty($state['Attributes'][$this->userIdAttribute])) {
-                SimpleSAML_Logger::debug(
+                SimpleSAML\Logger::debug(
                     "[attrauthvoms] process: Skipping user with no '"
                     . var_export($this->userIdAttribute, true). "' attribute");
                 return;
@@ -111,7 +113,7 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClient extends SimpleSAML_Auth_
 
     private function getVOs($userId)
     {
-        SimpleSAML_Logger::debug("[attrauthvoms] getVOs: userId="
+        SimpleSAML\Logger::debug("[attrauthvoms] getVOs: userId="
             . var_export($userId, true));
 
         $result = array();
@@ -124,7 +126,7 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClient extends SimpleSAML_Auth_
             while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
                 $result[] = $row;
             }
-            SimpleSAML_Logger::debug("[attrauthvoms] getVOs: result="
+            SimpleSAML\Logger::debug("[attrauthvoms] getVOs: result="
                 . var_export($result, true));
             return $result;
         } else {
@@ -136,8 +138,8 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClient extends SimpleSAML_Auth_
 
     private function showException($e)
     {
-        $globalConfig = SimpleSAML_Configuration::getInstance();
-        $t = new SimpleSAML_XHTML_Template($globalConfig, 'attrauthvoms:exception.tpl.php');
+        $globalConfig = SimpleSAML\Configuration::getInstance();
+        $t = new SimpleSAML\XHTML\Template($globalConfig, 'attrauthvoms:exception.tpl.php');
         $t->data['e'] = $e->getMessage();
         $t->show();
         exit();

--- a/lib/Auth/Process/COmanageDbClient.php
+++ b/lib/Auth/Process/COmanageDbClient.php
@@ -15,19 +15,19 @@ use SimpleSAML\XHTML\Template;
  *
  * Example configuration:
  *
- *    authproc = array(
+ *    authproc = [
  *       ...
- *       '60' => array(
+ *       '60' => [
  *            'class' => 'attrauthvoms:COmanageDbClient',
  *            'userIdAttribute' => 'distinguishedName',
- *       ),
+ *       ],
  *
  * @author Nicolas Liampotis <nliam@grnet.gr>
  */
 class COmanageDbClient extends ProcessingFilter
 {
     // List of SP entity IDs that should be excluded from this filter.
-    private $blacklist = array();
+    private $blacklist = [];
 
     private $userIdAttribute = 'distinguishedName';
 
@@ -38,7 +38,7 @@ class COmanageDbClient extends ProcessingFilter
         . ' subject = :subject';
 
     // List of VO names that should be excluded from entitlements.
-    private $voBlacklist = array();
+    private $voBlacklist = [];
 
     public function __construct($config, $reserved)
     {
@@ -109,9 +109,9 @@ class COmanageDbClient extends ProcessingFilter
                     if (empty($vo['vo_id']) || in_array($vo['vo_id'], $this->voBlacklist, true)) {
                         continue;
                     }
-                    $roles = array("member", "vm_operator"); // TODO
+                    $roles = ["member", "vm_operator"]; // TODO
                     if (empty($state['Attributes']['eduPersonEntitlement'])) {
-                        $state['Attributes']['eduPersonEntitlement'] = array();
+                        $state['Attributes']['eduPersonEntitlement'] = [];
                     }
                     foreach ($roles as $role) {
                         $entitlement =
@@ -135,11 +135,11 @@ class COmanageDbClient extends ProcessingFilter
         Logger::debug("[attrauthvoms] getVOs: userId="
             . var_export($userId, true));
 
-        $result = array();
+        $result = [];
         $db = Database::getInstance();
-        $queryParams = array(
-            'subject' => array($userId, PDO::PARAM_STR),
-        );
+        $queryParams = [
+            'subject' => [$userId, PDO::PARAM_STR],
+        ];
         $stmt = $db->read($this->voQuery, $queryParams);
         if ($stmt->execute()) {
             while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {

--- a/lib/Auth/Process/COmanageDbClientCertEntitlement.php
+++ b/lib/Auth/Process/COmanageDbClientCertEntitlement.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SimpleSAML\Module\attrauthvoms\Auth\Process;
+
 /**
  * COmanage DB authproc filter.
  *
@@ -32,7 +34,7 @@
  * @author Nicolas Liampotis <nliam@grnet.gr>
  * @author nikosev <nikos.ev@hotmail.com>
  */
-class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends SimpleSAML_Auth_ProcessingFilter
+class COmanageDbClientCertEntitlement extends SimpleSAML\Auth\ProcessingFilter
 {
     // List of SP entity IDs that should be excluded from this filter.
     private $spWhitelist = null;
@@ -71,9 +73,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
 
         if (array_key_exists('userIdAttribute', $config)) {
             if (!is_string($config['userIdAttribute'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthvoms][CertEntitlement] Configuration error: 'userIdAttribute' not a string literal");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthvoms configuration error: 'userIdAttribute' not a string literal");
             }
             $this->userIdAttribute = $config['userIdAttribute'];
@@ -81,9 +83,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
 
         if (array_key_exists('attributeName', $config)) {
             if (!is_string($config['attributeName'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthvoms][CertEntitlement] Configuration error: 'attributeName' not a string literal");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthvoms configuration error: 'attributeName' not a string literal");
             }
             $this->attributeName = $config['attributeName'];
@@ -91,9 +93,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
 
         if (array_key_exists('spWhitelist', $config)) {
             if (!is_array($config['spWhitelist'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthvoms][CertEntitlement] Configuration error: 'spWhitelist' not an array");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthvoms configuration error: 'spWhitelist' not an array");
             }
             $this->spWhitelist = $config['spWhitelist'];
@@ -101,9 +103,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
 
         if (array_key_exists('voBlacklist', $config)) {
             if (!is_array($config['voBlacklist'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthcomanage][CertEntitlement] Configuration error: 'voBlacklist' not an array");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthcomanage configuration error: 'voBlacklist' not an array");
             }
             $this->voBlacklist = $config['voBlacklist'];
@@ -111,9 +113,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
 
         if (array_key_exists('defaultRoles', $config)) {
             if (!is_array($config['defaultRoles'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthcomanage][CertEntitlement] Configuration error: 'defaultRoles' not an array");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthcomanage configuration error: 'defaultRoles' not an array");
             }
             $this->defaultRoles = $config['defaultRoles'];
@@ -121,9 +123,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
 
         if (array_key_exists('tableNames', $config)) {
             if (!is_array($config['tableNames'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthcomanage][CertEntitlement] Configuration error: 'tableNames' not an array");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthcomanage configuration error: 'tableNames' not an array");
             }
             $this->tableNames = $config['tableNames'];
@@ -131,9 +133,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
 
         if (array_key_exists('role_urn_namespace', $config)) {
             if (!is_string($config['role_urn_namespace'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthvoms][CertEntitlement] Configuration error: 'role_urn_namespace' not a string literal");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthvoms configuration error: 'role_urn_namespace' not a string literal");
             }
             $this->roleUrnNamespace = $config['role_urn_namespace'];
@@ -141,9 +143,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
 
         if (array_key_exists('role_authority', $config)) {
             if (!is_string($config['role_authority'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthvoms][CertEntitlement] Configuration error: 'role_authority' not a string literal");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthvoms configuration error: 'role_authority' not a string literal");
             }
             $this->roleAuthority = $config['role_authority'];
@@ -151,9 +153,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
 
         if (array_key_exists('defaultIssuerDn', $config)) {
             if (!is_string($config['defaultIssuerDn'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthvoms][CertEntitlement] Configuration error: 'defaultIssuerDn' not a string literal");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthvoms configuration error: 'defaultIssuerDn' not a string literal");
             }
             $this->defaultIssuerDn = $config['defaultIssuerDn'];
@@ -161,9 +163,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
 
         if (array_key_exists('allowEmptyRole', $config)) {
             if (!is_bool($config['allowEmptyRole'])) {
-                SimpleSAML_Logger::error(
+                SimpleSAML\Logger::error(
                     "[attrauthvoms][CertEntitlement] Configuration error: 'allowEmptyRole' not boolean");
-                throw new SimpleSAML_Error_Exception(
+                throw new SimpleSAML\Error\Exception(
                     "attrauthvoms configuration error: 'allowEmptyRole' not a string literal");
             }
             $this->allowEmptyRole = $config['allowEmptyRole'];
@@ -175,13 +177,13 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
         try {
             assert(is_array($state));
             if (isset($state['SPMetadata']['entityid']) && isset($this->spWhitelist) && !in_array($state['SPMetadata']['entityid'], $this->spWhitelist, true)) {
-                SimpleSAML_Logger::debug(
+                SimpleSAML\Logger::debug(
                     "[attrauthvoms][CertEntitlement] process: Skipping not whitelisted SP "
                     . var_export($state['SPMetadata']['entityid'], true));
                 return;
             }
             if (empty($state['Attributes'][$this->userIdAttribute])) {
-                SimpleSAML_Logger::debug(
+                SimpleSAML\Logger::debug(
                     "[attrauthvoms][CertEntitlement] process: Skipping user with no '"
                     . var_export($this->userIdAttribute, true). "' attribute");
                 return;
@@ -194,9 +196,9 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
                     $vos = $this->getVOs($userId, $tableName);
                     $totalVos = array_merge($totalVos, $vos);
                 }
-                SimpleSAML_Logger::debug("[attrauthvoms][CertEntitlement]: vos=" . var_export($totalVos, true));
+                SimpleSAML\Logger::debug("[attrauthvoms][CertEntitlement]: vos=" . var_export($totalVos, true));
                 foreach ($totalVos as $vo) {
-                    SimpleSAML_Logger::debug("[attrauthvoms][CertEntitlement]: vo=" . var_export($vo, true));
+                    SimpleSAML\Logger::debug("[attrauthvoms][CertEntitlement]: vo=" . var_export($vo, true));
                     if (empty($vo['vo_id']) || in_array($vo['vo_id'], $this->voBlacklist, true)) {
                         continue;
                     }
@@ -235,7 +237,7 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
                 $jsonString = "{\"cert_entitlement\": [";
                 $jsonString .= implode(',', $certEntitlements);
                 $jsonString .= "]}";
-                SimpleSAML_Logger::debug("[attrauthvoms][CertEntitlement] process: jsonString=" . var_export($jsonString, true));
+                SimpleSAML\Logger::debug("[attrauthvoms][CertEntitlement] process: jsonString=" . var_export($jsonString, true));
                 $state['Attributes'][$this->attributeName] = array(utf8_encode($jsonString));
             }
         } catch (\Exception $e) {
@@ -245,7 +247,7 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
 
     private function getVOs($userId, $tableName)
     {
-        SimpleSAML_Logger::debug("[attrauthvoms][CertEntitlement] getVOs: userId="
+        SimpleSAML\Logger::debug("[attrauthvoms][CertEntitlement] getVOs: userId="
             . var_export($userId, true));
 
         $result = array();
@@ -263,7 +265,7 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
             while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
                 $result[] = $row;
             }
-            SimpleSAML_Logger::debug("[attrauthvoms][CertEntitlement] getVOs: result="
+            SimpleSAML\Logger::debug("[attrauthvoms][CertEntitlement] getVOs: result="
                 . var_export($result, true));
             return $result;
         } else {
@@ -280,14 +282,14 @@ class sspmod_attrauthvoms_Auth_Process_COmanageDbClientCertEntitlement extends S
             . "\"cert_iss\": \"" . (empty($issuerDn) ? $this->defaultIssuerDn : $issuerDn) . "\","
             . "\"eduperson_entitlement\": \"" . $entitlementValue . "\""
             . "}";
-        SimpleSAML_Logger::debug("[attrauthvoms][CertEntitlement]: jsonEntitlement=" . var_export($jsonEntitlement, true));
+        SimpleSAML\Logger::debug("[attrauthvoms][CertEntitlement]: jsonEntitlement=" . var_export($jsonEntitlement, true));
         return array_merge($entitlementArray, [$jsonEntitlement]);
     }
 
     private function showException($e)
     {
-        $globalConfig = SimpleSAML_Configuration::getInstance();
-        $t = new SimpleSAML_XHTML_Template($globalConfig, 'attrauthvoms:exception.tpl.php');
+        $globalConfig = SimpleSAML\Configuration::getInstance();
+        $t = new SimpleSAML\XHTML\Template($globalConfig, 'attrauthvoms:exception.tpl.php');
         $t->data['e'] = $e->getMessage();
         $t->show();
         exit();

--- a/lib/Auth/Process/COmanageDbClientCertEntitlement.php
+++ b/lib/Auth/Process/COmanageDbClientCertEntitlement.php
@@ -15,29 +15,29 @@ use SimpleSAML\XHTML\Template;
  *
  * Example configuration:
  *
- *    authproc = array(
+ *    authproc = [
  *       ...
- *       61 => array(
+ *       61 => [
  *           'class' => 'attrauthvoms:COmanageDbClientCertEntitlement',
  *           'userIdAttribute' => 'distinguishedName',
  *           'attributeName' => 'certEntitlement',
- *           'spWhitelist' => array(
+ *           'spWhitelist' => [
  *               'https://aai-dev.egi.eu/registry/shibboleth',
  *               'https://snf-766637.vm.okeanos.grnet.gr/Shibboleth.sso/Metadata',
  *               'https://am02.pilots.aarc-project.eu/shibboleth',
- *           ),
- *           'defaultRoles' => array(
+ *           ],
+ *           'defaultRoles' => [
  *               'member',
  *               'vm_operator'
- *           ),
- *           'voBlacklist' => array(
+ *           ],
+ *           'voBlacklist' => [
  *               'vo.example01.org',
  *               'vo.example02.org',
- *           ),
+ *           ],
  *           'role_urn_namespace' => 'urn:mace:example.org',
  *           'role_authority' => 'www.example.org',
  *           'defaultIssuerDn' => 'IGTF',
- *       ),
+ *       ],
  *
  * @author Nicolas Liampotis <nliam@grnet.gr>
  * @author nikosev <nikos.ev@hotmail.com>
@@ -60,13 +60,13 @@ class COmanageDbClientCertEntitlement extends ProcessingFilter
         . ' subject = :subject';
 
     // List of VO names that should be excluded from entitlements.
-    private $voBlacklist = array();
+    private $voBlacklist = [];
 
-    private $defaultRoles = array();
+    private $defaultRoles = [];
 
     private $allowEmptyRole = false;
 
-    private $tableNames = array();
+    private $tableNames = [];
 
     private $roleUrnNamespace;
 
@@ -287,7 +287,7 @@ class COmanageDbClientCertEntitlement extends ProcessingFilter
                 $jsonString .= implode(',', $certEntitlements);
                 $jsonString .= "]}";
                 Logger::debug("[attrauthvoms][CertEntitlement] process: jsonString=" . var_export($jsonString, true));
-                $state['Attributes'][$this->attributeName] = array(utf8_encode($jsonString));
+                $state['Attributes'][$this->attributeName] = [utf8_encode($jsonString)];
             }
         } catch (\Exception $e) {
             $this->showException($e);
@@ -299,11 +299,11 @@ class COmanageDbClientCertEntitlement extends ProcessingFilter
         Logger::debug("[attrauthvoms][CertEntitlement] getVOs: userId="
             . var_export($userId, true));
 
-        $result = array();
+        $result = [];
         $db = Database::getInstance();
-        $queryParams = array(
-            'subject' => array($userId, PDO::PARAM_STR),
-        );
+        $queryParams = [
+            'subject' => [$userId, PDO::PARAM_STR],
+        ];
 
         $strParams = [
             ':tableName' => $tableName,


### PR DESCRIPTION
This PR contains the required changes to support SimpleSAMLphp v1.17 and changes of code style based on PSR-12.
- Comply to [PSR-4: Autoloader](https://www.php-fig.org/psr/psr-4/) guidelines
- Comply to [PSR-1: Basic Coding Standard](https://www.php-fig.org/psr/psr-1/) guidelines
- Comply to [PSR-12: Extended Coding Style](https://www.php-fig.org/psr/psr-12/) guidelines
- Apply modern array syntax to comply with [SimpleSAMLphp v1.17](https://simplesamlphp.org/docs/stable/simplesamlphp-upgrade-notes-1.17)